### PR TITLE
Schedule NSURLConnection on all common runloop modes

### DIFF
--- a/sdk/internal/ANAdFetcher.m
+++ b/sdk/internal/ANAdFetcher.m
@@ -110,7 +110,9 @@ NSString *const kANAdFetcherMediatedClassKey = @"kANAdFetcherMediatedClassKey";
 		if (self.URL != nil)
 		{
             self.request = ANBasicRequestWithURL(self.URL);
-			self.connection = [NSURLConnection connectionWithRequest:self.request delegate:self];
+            self.connection = [[NSURLConnection alloc] initWithRequest:self.request delegate:self startImmediately:NO];
+            [self.connection scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:NSRunLoopCommonModes];
+            [self.connection start];
 			
 			if (self.connection != nil)
 			{


### PR DESCRIPTION
By default, an NSURLConnection doesn't run during the touch event processing runloop. The direct sideeffect of this is that during scrolling in a tableview/collectionview ads won't get loaded until the touch event is finished (finger lifted from screen).

There are several ways to deal with that:

1. Schedule the NSURLConnection across all common runloop modes (which includes the touch handling runloop), which is what this PR does.
2. Use a dedicated thread for networking and schedule the runloop in that.
3. Use NSURLSession. It’s the modern alternative to NSURLConnection.