### PR TITLE
Added a notification to fire before showing a mediated ad network. Th…

### DIFF
--- a/sdk/internal/ANInterstitialAd.m
+++ b/sdk/internal/ANInterstitialAd.m
@@ -25,6 +25,8 @@
 #import "ANMRAIDContainerView.h"
 
 static NSTimeInterval const kANInterstitialAdTimeout = 270.0;
+static NSString *const ETRAppNexusShowingMediatedAdNotification = @"ETRAppNexusShowingMediatedAd";
+
 
 // List of allowed ad sizes for interstitials.  These must fit in the
 // maximum size of the view, which in this case, will be the size of
@@ -146,6 +148,9 @@ NSString *const kANInterstitialAdViewAuctionInfoKey = @"kANInterstitialAdViewAuc
                                  animated:YES
                                completion:nil];
     } else if ([adToShow conformsToProtocol:@protocol(ANCustomAdapterInterstitial)]) {
+        NSString *adToShowClassName = NSStringFromClass([adToShow class]);
+        NSDictionary* userInfo = @{@"ETRANMEdiatedAdNetworkClassName": adToShowClassName};
+        [[NSNotificationCenter defaultCenter] postNotificationName:ETRAppNexusShowingMediatedAdNotification object:self userInfo:userInfo];
         [adToShow presentFromViewController:controller];
         if (auctionID) {
             ANPBContainerView *logoView = [[ANPBContainerView alloc] initWithLogo];


### PR DESCRIPTION
Added a notification for when ads are about to be shown. This can be used in eTracksApp to track which network is showing ads in crashlytics. Will solve many many headaches when ads start to crash and we have no clue which networks they are coming from