### PR TITLE
Fix crash when querying for creativeId

### DIFF
--- a/BinaryProjects/ANSDK.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/BinaryProjects/ANSDK.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/BinaryProjects/ANSDK.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/BinaryProjects/ANSDK.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>IDEDidComputeMac32BitWarning</key>
-	<true/>
-</dict>
-</plist>

--- a/sdk/internal/ANBaseAdObject.h
+++ b/sdk/internal/ANBaseAdObject.h
@@ -18,11 +18,11 @@
 @interface ANBaseAdObject : NSObject
 
 
-@property (nonatomic, readwrite, strong) NSString *content;
-@property (nonatomic, readwrite, strong) NSString *height;
-@property (nonatomic, readwrite, strong) NSString *width;
-@property (nonatomic, readwrite, assign) NSString *creativeId;
-@property (nonatomic, readwrite, strong)  NSArray<NSString *>  *impressionUrls;
+@property (nonatomic, readwrite, copy) NSString *content;
+@property (nonatomic, readwrite, copy) NSString *height;
+@property (nonatomic, readwrite, copy) NSString *width;
+@property (nonatomic, readwrite, copy) NSString *creativeId;
+@property (nonatomic, readwrite, copy)  NSArray<NSString *>  *impressionUrls;
 
 
 @end


### PR DESCRIPTION
Crash is in `ANGlobal.m + (id) valueOfGetterProperty: (NSString *)stringOfGetterProperty
                   forObject: (id)objectImplementingGetterProperty`

`*** -[CFString retain]: message sent to deallocated instance 0x1290fb80`

In general when dealing with mutable properties of type NSString * on Obj-C, the best practice is to use copy.