### PR TITLE
Add warmup method to ANSDKSettings

### DIFF
--- a/sdk/ANSDKSettings.h
+++ b/sdk/ANSDKSettings.h
@@ -21,6 +21,7 @@
 
 + (instancetype)sharedInstance;
 
+- (void)warmUp;
 /**
  If YES, the SDK will make all requests in HTTPS. Default is NO.
  */

--- a/sdk/internal/config/ANSDKSettings.m
+++ b/sdk/internal/config/ANSDKSettings.m
@@ -117,6 +117,10 @@
     return sdkSettings;
 }
 
+- (void)warmUp {
+    ANUserAgent();
+}
+
 - (id<ANBaseUrlConfig>)baseUrlConfig {
     if (!_baseUrlConfig) {
         if (self.HTTPSEnabled) {


### PR DESCRIPTION
Calling `ANUserAgent` function for the first time is quite costy (CPU-wise). 
Adding warmup function to ANSDKSettings.m(? might not be the best place) would allow developers to do this heavy work up front at the time of their choosing and make first ad loading smooth ( not dropping frames while scrolling )