### PR TITLE
Created the NativeAdClickHandling enum

### DIFF
--- a/sdk/native/ANNativeAdResponse.h
+++ b/sdk/native/ANNativeAdResponse.h
@@ -20,6 +20,11 @@
 #import "ANAdConstants.h"
 #import "ANAdProtocol.h"
 
+typedef enum {
+    NativeAdClickHandlingFull,
+    NativeAdClickHandlingTrackingOnly
+} NativeAdClickHandling;
+
 /*!
  * Contains native ad assets as well as defines the process by which a native view can be registered for impression
  * tracking and click handling.
@@ -140,6 +145,12 @@
  * @see ANNativeAdDelegate
  */
 @property (nonatomic, readwrite, weak) id<ANNativeAdDelegate> delegate;
+
+
+/*!
+ * clickHandling sepcifies how clicks should handled, either full handling or only tracking in which case opening the ad should be handled by the client
+ */
+@property (nonatomic, readwrite, assign) NativeAdClickHandling clickHandling;
 
 /*!
  * Should be called when the native view has been populated with the ad elements and will be displayed.

--- a/sdk/native/internal/ANNativeAdResponse.m
+++ b/sdk/native/internal/ANNativeAdResponse.m
@@ -58,8 +58,14 @@
 
 @synthesize  opensInNativeBrowser           = _opensInNativeBrowser;
 @synthesize  landingPageLoadsInBackground   = _landingPageLoadsInBackground;
+@synthesize  clickHandling                  = _clickHandling;
 
-
+- (instancetype)init {
+    if (self = [super init]) {
+        _clickHandling = NativeAdClickHandlingFull;
+    }
+    return self;
+}
 
 #pragma mark - Registration
 

--- a/sdk/native/internal/ANNativeStandardAdResponse.m
+++ b/sdk/native/internal/ANNativeStandardAdResponse.m
@@ -153,6 +153,10 @@
     [self adWasClicked];
     [self fireClickTrackers];
     
+    if (self.clickHandling == NativeAdClickHandlingTrackingOnly) {
+        return;
+    }
+    
     BOOL successfullyOpenedBrowserWithClickURL = [self openIntendedBrowserWithURL:self.clickURL];
     if (!successfullyOpenedBrowserWithClickURL) {
         ANLogDebug(@"Could not open click URL: %@", self.clickURL);


### PR DESCRIPTION
 Created the NativeAdClickHandling enum to specify whether ANNativeAdResponse should handle clicks fully or only tracking in which case the client code should handle clicks to open the Ad, because some clients need to open the Ad natively in their application but yet need the benefit of Ad click tracking.