### PR TITLE
Allow other magic sizes than 1x1, add loadedAdSize

### DIFF
--- a/BinaryProjects/ANSDK.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/BinaryProjects/ANSDK.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/BinaryProjects/ANSDK.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/BinaryProjects/ANSDK.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>IDEDidComputeMac32BitWarning</key>
-	<true/>
-</dict>
-</plist>

--- a/sdk/ANBannerAdView.h
+++ b/sdk/ANBannerAdView.h
@@ -201,6 +201,8 @@ typedef NS_ENUM(NSUInteger, ANBannerViewAdAlignment) {
 - (void) loadAd;
 
 
+@property (nonatomic, assign, readonly) CGSize loadedAdSize;
+
 @end
 
 

--- a/sdk/ANSDKSettings.h
+++ b/sdk/ANSDKSettings.h
@@ -29,4 +29,9 @@
  */
 @property (nonatomic) BOOL HTTPSEnabled;
 
+/**
+ Special ad sizes for which the content view should be constrained to the container view.
+ */
+@property (nonatomic, copy) NSArray<NSValue *> *sizesThatShouldConstrainToSuperview;
+
 @end

--- a/sdk/Categories/ANBannerAdView+ANContentViewTransitions.m
+++ b/sdk/Categories/ANBannerAdView+ANContentViewTransitions.m
@@ -14,6 +14,7 @@
  */
 
 #import "ANBannerAdView+ANContentViewTransitions.h"
+#import "ANSDKSettings.h"
 
 static NSString *const kANContentViewTransitionsOldContentViewTransitionKey = @"AppNexusOldContentViewTransition";
 static NSString *const kANContentViewTransitionsNewContentViewTransitionKey = @"AppNexusNewContentViewTransition";
@@ -139,7 +140,10 @@ static NSString *const kANContentViewTransitionsNewContentViewTransitionKey = @"
 
 - (void)constrainContentView {
     self.contentView.translatesAutoresizingMaskIntoConstraints = NO;
-    if(CGSizeEqualToSize([self adSize], CGSizeMake(1, 1))){
+    
+    BOOL shouldConstrainToSuperview = [ANSDKSettings.sharedInstance.sizesThatShouldConstrainToSuperview containsObject:[NSValue valueWithCGSize:self.contentView.bounds.size]];
+    
+    if(CGSizeEqualToSize([self adSize], CGSizeMake(1, 1)) || shouldConstrainToSuperview){
         
         [self.contentView an_constrainToSizeOfSuperview];
         [self.contentView an_alignToSuperviewWithXAttribute:NSLayoutAttributeLeft

--- a/sdk/internal/ANBannerAdView.m
+++ b/sdk/internal/ANBannerAdView.m
@@ -41,6 +41,8 @@
 
 @property (nonatomic, readwrite, strong)  NSArray<NSString *>   *impressionURLs;
 
+@property (nonatomic, readwrite, assign) CGSize loadedAdSize;
+
 @end
 
 
@@ -68,6 +70,7 @@
 
     _adSize                 = APPNEXUS_SIZE_UNDEFINED;
     _adSizes                = nil;
+    _loadedAdSize           = APPNEXUS_SIZE_UNDEFINED;
     self.allowSmallerSizes  = NO;
 }
 
@@ -322,6 +325,13 @@
 
         if ([contentView isKindOfClass:[UIView class]]) 
         {
+            if ([contentView conformsToProtocol:@protocol(ANAdContainer)]) {
+                id <ANAdContainer> adContainer = (id <ANAdContainer>)contentView;
+                self.loadedAdSize = adContainer.size;
+            } else {
+                self.loadedAdSize = self.adSize;
+            }
+            
             self.contentView = contentView;
             [self adDidReceiveAd];
             

--- a/sdk/internal/ANUniversalTagRequestBuilder.m
+++ b/sdk/internal/ANUniversalTagRequestBuilder.m
@@ -181,15 +181,13 @@
     
     NSString *invCode = [self.adFetcherDelegate inventoryCode];
     NSInteger memberId = [self.adFetcherDelegate memberId];
-    if(invCode && memberId>0){
+    if (invCode && memberId > 0) {
         tagDict[@"code"] = invCode;
         requestDict[@"member_id"] = @(memberId);
-    }else {
+    } else {
         tagDict[@"id"] = @(placementId);
     }
 
-    
-    //
     NSDictionary             *delegateReturnDictionary  = [self.adFetcherDelegate internalDelegateUniversalTagSizeParameters];
 
     CGSize                    primarySize               = [[delegateReturnDictionary  objectForKey:ANInternalDelgateTagKeyPrimarySize] CGSizeValue];

--- a/sdk/internal/MRAID/ANMRAIDContainerView.h
+++ b/sdk/internal/MRAID/ANMRAIDContainerView.h
@@ -21,9 +21,12 @@
 
 @protocol ANAdViewInternalDelegate;
 
+@protocol ANAdContainer
+- (CGSize)size;
+@end
 
 
-@interface ANMRAIDContainerView : UIView
+@interface ANMRAIDContainerView : UIView <ANAdContainer>
 
 - (instancetype)initWithSize:(CGSize)size
                         HTML:(NSString *)html


### PR DESCRIPTION
Support ticket no. 00205194

It's possible to have magic sizes other than 1x1, for us it's 3x3 and to us it means that we should display it as fullscreen ad using parallax effect. 

Current AppNexus iOS SDK implementation only respects 1x1 as magic size ( when size is 1x1, ad is resized to match the parent view ).
So when we request the ad using 3x3 size it actually is rendered as 3x3.
We would like to propose the following changes to your SDK to allow us and other publishers to define custom magic ad sizes

List of changes:

- `ANSDKSettings` - one addition here is `sizesThatShouldConstrainToSuperview` property, to allow clients to inject their magic sizes.
```
/**
 Special ad sizes for which the content view should be constrained to the container view.
 */
@property (nonatomic, copy) NSArray<NSValue *> *sizesThatShouldConstrainToSuperview; 
```

- `ANBannerAdView+ANContentViewTransitions.m` - in method `- (void)constrainContentView`

Instead of:
```
if(CGSizeEqualToSize([self adSize], CGSizeMake(1, 1))){
```
👇 
```
BOOL shouldConstrainToSuperview = [ANSDKSettings.sharedInstance.sizesThatShouldConstrainToSuperview containsObject: [NSValue valueWithCGSize:self.contentView.bounds.size]];

 if(CGSizeEqualToSize([self adSize], CGSizeMake(1, 1)) || shouldConstrainToSuperview){
```

- `ANBannerAdView.h` - added `loadedAdSize` property, so we can know what is the actual size of the loaded ad. Currently we are using the KVC hack.
 
loadedAdSize property is set when ad is loaded, so inside `- (void)universalAdFetcher:(ANUniversalAdFetcher *)fetcher didFinishRequestWith ….` callback we've added following logic:

```
            if ([contentView conformsToProtocol:@protocol(ANAdContainer)]) {
                id <ANAdContainer> adContainer = (id <ANAdContainer>)contentView;
                self.loadedAdSize = adContainer.size;
            } else {
                self.loadedAdSize = self.adSize;
            }
```

We’ve also introduced small protocol called `ANAdContainer` to hide actual view class.
```
@protocol ANAdContainer
- (CGSize)size;
@end
```

currently only `ANMRAIDContainerView` conforms to it.