### PR TITLE
FIx Carthage build - Remove hardcoding for SDKROOT

### DIFF
--- a/BinaryProjects/ANSDK.xcodeproj/project.pbxproj
+++ b/BinaryProjects/ANSDK.xcodeproj/project.pbxproj
@@ -4197,7 +4197,6 @@
 				IBC_FLATTEN_NIBS = NO;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				ONLY_ACTIVE_ARCH = YES;
-				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SYMROOT = build;
 			};
@@ -4245,7 +4244,6 @@
 				IBC_FLATTEN_NIBS = NO;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				ONLY_ACTIVE_ARCH = NO;
-				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SYMROOT = build;
 				VALIDATE_PRODUCT = YES;
@@ -4306,7 +4304,6 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
 				SYMROOT = build;
 				WRAPPER_EXTENSION = bundle;
 			};
@@ -4324,7 +4321,6 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
 				SYMROOT = build;
 				WRAPPER_EXTENSION = bundle;
 			};


### PR DESCRIPTION
```
*** Building scheme "AppNexusSDK" in ANSDK.xcodeproj
Failed to write to /Users/akring/src/mobile/iOS/Carthage/Build/iOS/AppNexusSDK.framework: Error Domain=NSCocoaErrorDomain Code=260 "The file “AppNexusSDK.framework” couldn’t be opened because there is no such file." UserInfo={NSURL=file:///Users/akring/src/mobile/iOS/Carthage/Checkouts/mobile-sdk-ios/BinaryProjects/build/ArchiveIntermediates/AppNexusSDK/BuildProductsPath/Debug-iphoneos/AppNexusSDK.framework, NSFilePath=/Users/akring/src/mobile/iOS/Carthage/Checkouts/mobile-sdk-ios/BinaryProjects/build/ArchiveIntermediates/AppNexusSDK/BuildProductsPath/Debug-iphoneos/AppNexusSDK.framework, NSUnderlyingError=0x7fb3fca849e0 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
```