### PR TITLE
support custom javascript

### DIFF
--- a/sdk/sourcefiles/ANAdProtocol.h
+++ b/sdk/sourcefiles/ANAdProtocol.h
@@ -70,6 +70,11 @@
  */
 @property (nonatomic, readwrite, strong, nullable) NSString *externalUid;
 
+/**
+ Custom JavaScript to be executed on document start
+ */
+@property (nonatomic, readwrite, strong, nullable) NSString *customJavaScript;
+
 
 /**
  Set the user's current location.  This allows ad buyers to do location

--- a/sdk/sourcefiles/internal/ANAdView.m
+++ b/sdk/sourcefiles/internal/ANAdView.m
@@ -62,6 +62,7 @@
 // ANAdProtocol properties.
 //
 @synthesize  placementId                            = __placementId;
+@synthesize  customJavaScript                       = __customJavaScript;
 @synthesize  publisherId                            = __publisherId;
 @synthesize  memberId                               = __memberId;
 @synthesize  inventoryCode                          = __invCode;
@@ -254,6 +255,12 @@
     }
 }
 
+- (void)setCustomJavaScript:(nullable NSString *)customJavaScript {
+    if (customJavaScript != __customJavaScript) {
+        ANLogDebug(@"Setting customJavaScript to %@", customJavaScript);
+        __customJavaScript = customJavaScript;
+    }
+}
 
 - (void)setPlacementId:(nullable NSString *)placementId {
     placementId = ANConvertToNSString(placementId);
@@ -403,6 +410,11 @@
     return __placementId;
 }
 
+- (nullable NSString *)customJavaScript {
+    ANLogDebug(@"customJavaScript returned %@", __customJavaScript);
+    return __customJavaScript;
+}
+
 - (NSInteger )memberId {
     ANLogDebug(@"memberId returned %d", (int)__memberId);
     return __memberId;
@@ -463,11 +475,11 @@
     if (_universalAdFetcher) {
         return  _universalAdFetcher;
     }
-
+    
     if (self.marManager) {
-        _universalAdFetcher = [[ANUniversalAdFetcher alloc] initWithDelegate:self andAdUnitMultiAdRequestManager:self.marManager];
+        _universalAdFetcher = [[ANUniversalAdFetcher alloc] initWithDelegate:self andAdUnitMultiAdRequestManager:self.marManager andCustomJavaScript:self.customJavaScript];
     } else {
-        _universalAdFetcher = [[ANUniversalAdFetcher alloc] initWithDelegate:self];
+        _universalAdFetcher = [[ANUniversalAdFetcher alloc] initWithDelegate:self andCustomJavaScript:self.customJavaScript];
     }
 
     return  _universalAdFetcher;

--- a/sdk/sourcefiles/internal/ANAdWebViewController.h
+++ b/sdk/sourcefiles/internal/ANAdWebViewController.h
@@ -55,24 +55,29 @@
 
 - (instancetype)initWithSize:(CGSize)size
                          URL:(NSURL *)URL
-              webViewBaseURL:(NSURL *)baseURL;
+              webViewBaseURL:(NSURL *)baseURL
+            customJavaScript:(NSString *)javaScript;
 
 - (instancetype)initWithSize:(CGSize)size
                          URL:(NSURL *)URL
               webViewBaseURL:(NSURL *)baseURL
-               configuration:(ANAdWebViewControllerConfiguration *)configuration;
-
-- (instancetype)initWithSize:(CGSize)size
-                        HTML:(NSString *)html
-              webViewBaseURL:(NSURL *)baseURL;
+               configuration:(ANAdWebViewControllerConfiguration *)configuration
+            customJavaScript:(NSString *)javaScript;
 
 - (instancetype)initWithSize:(CGSize)size
                         HTML:(NSString *)html
               webViewBaseURL:(NSURL *)baseURL
-               configuration:(ANAdWebViewControllerConfiguration *)configuration;
+            customJavaScript:(NSString *)javaScript;
+
+- (instancetype)initWithSize:(CGSize)size
+                        HTML:(NSString *)html
+              webViewBaseURL:(NSURL *)baseURL
+               configuration:(ANAdWebViewControllerConfiguration *)configuration
+            customJavaScript:(NSString *)javaScript;
 
 - (instancetype) initWithSize: (CGSize)size
-                     videoXML: (NSString *)videoXML;
+                     videoXML: (NSString *)videoXML
+             customJavaScript:(NSString *)javaScript;
 
 
 - (void)adDidFinishExpand;

--- a/sdk/sourcefiles/internal/ANAdWebViewController.m
+++ b/sdk/sourcefiles/internal/ANAdWebViewController.m
@@ -96,11 +96,13 @@ NSString * __nonnull const  kANLandscape     = @"landscape";
 - (instancetype)initWithSize:(CGSize)size
                          URL:(NSURL *)URL
               webViewBaseURL:(NSURL *)baseURL
+            customJavaScript:(NSString *)javaScript
 {
     self = [self initWithSize:size
                           URL:URL
                webViewBaseURL:baseURL
-                configuration:nil];
+                configuration:nil
+            customJavaScript:javaScript];
     return self;
     
 }
@@ -109,6 +111,7 @@ NSString * __nonnull const  kANLandscape     = @"landscape";
                          URL:(NSURL *)URL
               webViewBaseURL:(NSURL *)baseURL
                configuration:(ANAdWebViewControllerConfiguration *)configuration
+            customJavaScript:(NSString *)javaScript
 {
     self = [self initWithConfiguration:configuration];
     if (!self)  { return nil; }
@@ -116,7 +119,7 @@ NSString * __nonnull const  kANLandscape     = @"landscape";
     _webView = [[ANWebView alloc]initWithSize:(CGSize)size
                                    URL:(NSURL *)URL
                                baseURL:(NSURL *)baseURL];
-    [self loadWebViewWithUserScripts];
+    [self loadWebViewWithUserScripts:javaScript];
     
     return self;
 }
@@ -124,11 +127,13 @@ NSString * __nonnull const  kANLandscape     = @"landscape";
 - (instancetype)initWithSize:(CGSize)size
                         HTML:(NSString *)html
               webViewBaseURL:(NSURL *)baseURL
+            customJavaScript:(NSString *)javaScript
 {
     self = [self initWithSize:size
                          HTML:html
                webViewBaseURL:baseURL
-                configuration:nil];
+                configuration:nil
+            customJavaScript:javaScript];
     return self;
 }
 
@@ -136,6 +141,7 @@ NSString * __nonnull const  kANLandscape     = @"landscape";
                         HTML:(NSString *)html
               webViewBaseURL:(NSURL *)baseURL
                configuration:(ANAdWebViewControllerConfiguration *)configuration
+            customJavaScript:(NSString *)javaScript
 {
     self = [self initWithConfiguration:configuration];
     if (!self)  { return nil; }
@@ -157,12 +163,13 @@ NSString * __nonnull const  kANLandscape     = @"landscape";
     }
     _webView = [[ANWebView alloc] initWithSize:size content:htmlToLoad baseURL:base];
     //[self createWebView:size HTML:htmlToLoad baseURL:base];
-    [self loadWebViewWithUserScripts];
+    [self loadWebViewWithUserScripts:javaScript];
     return self;
 }
 
 - (instancetype) initWithSize: (CGSize)size
-                     videoXML: (NSString *)videoXML;
+                     videoXML: (NSString *)videoXML
+             customJavaScript:(NSString *)javaScript
 {
     self = [self initWithConfiguration:nil];
     if (!self)  { return nil; }
@@ -177,7 +184,7 @@ NSString * __nonnull const  kANLandscape     = @"landscape";
     
     _webView = [[ANWebView alloc] initWithSize:size URL:[[[ANSDKSettings sharedInstance] baseUrlConfig] videoWebViewUrl]];
     
-    [self loadWebViewWithUserScripts];
+    [self loadWebViewWithUserScripts:javaScript];
     
     UIWindow  *currentWindow  = [UIApplication sharedApplication].keyWindow;
     [currentWindow addSubview:self.webView];
@@ -261,7 +268,7 @@ NSString * __nonnull const  kANLandscape     = @"landscape";
 
 #pragma mark - configure WKWebView
  
--(void) loadWebViewWithUserScripts {
+-(void) loadWebViewWithUserScripts:(NSString *)javaScript {
     
     WKUserContentController  *controller  = self.webView.configuration.userContentController;
     
@@ -272,6 +279,13 @@ NSString * __nonnull const  kANLandscape     = @"landscape";
     WKUserScript *anjamScript = [[WKUserScript alloc] initWithSource: [[self class] anjamJS]
                                                        injectionTime: WKUserScriptInjectionTimeAtDocumentStart
                                                     forMainFrameOnly: YES];
+    
+    if (javaScript != NULL) {
+        WKUserScript *customScript = [[WKUserScript alloc] initWithSource: javaScript
+           injectionTime: WKUserScriptInjectionTimeAtDocumentStart
+        forMainFrameOnly: YES];
+        [controller addUserScript:customScript];
+    }
     
     [controller addUserScript:anjamScript];
     [controller addUserScript:mraidScript];

--- a/sdk/sourcefiles/internal/ANMultiAdRequest.m
+++ b/sdk/sourcefiles/internal/ANMultiAdRequest.m
@@ -280,7 +280,7 @@ NSInteger const  kMARAdUnitIndexNotFound  = -1;
 
     _adUnits             = [NSPointerArray weakObjectsPointerArray];
 
-    _universalAdFetcher  = [[ANUniversalAdFetcher alloc] initWithMultiAdRequestManager: self];
+    _universalAdFetcher  = [[ANUniversalAdFetcher alloc] initWithMultiAdRequestManager: self andCustomJavaScript:self.customJavaScript];
 
     //
     __memberId          = memberId;

--- a/sdk/sourcefiles/internal/ANSSMMediationAdViewController.m
+++ b/sdk/sourcefiles/internal/ANSSMMediationAdViewController.m
@@ -191,7 +191,8 @@
     
     self.ssmAdView = [[ANMRAIDContainerView alloc] initWithSize:sizeofWebView
                                                            HTML:self.ssmMediatedAd.content
-                                                 webViewBaseURL:[NSURL URLWithString:[[[ANSDKSettings sharedInstance] baseUrlConfig] webViewBaseUrl]]];
+                                                 webViewBaseURL:[NSURL URLWithString:[[[ANSDKSettings sharedInstance] baseUrlConfig] webViewBaseUrl]]
+                                                customJavaScript:nil];
     self.ssmAdView.loadingDelegate = self;
     // Allow ANJAM events to always be passed to the ANAdView
     self.ssmAdView.webViewController.adViewANJAMDelegate = self.adViewDelegate;

--- a/sdk/sourcefiles/internal/ANUniversalAdFetcher.h
+++ b/sdk/sourcefiles/internal/ANUniversalAdFetcher.h
@@ -35,9 +35,9 @@
 
 @interface ANUniversalAdFetcher : ANAdFetcherBase
 
-- (nonnull instancetype)initWithDelegate:(nonnull id)delegate;
-- (nonnull instancetype)initWithDelegate:(nonnull id)delegate andAdUnitMultiAdRequestManager:(nonnull ANMultiAdRequest *)adunitMARManager;
-- (nonnull instancetype)initWithMultiAdRequestManager:(nonnull ANMultiAdRequest *)marManager;
+- (nonnull instancetype)initWithDelegate:(nonnull id)delegate andCustomJavaScript:(nonnull NSString *)javaScript;
+- (nonnull instancetype)initWithDelegate:(nonnull id)delegate andAdUnitMultiAdRequestManager:(nonnull ANMultiAdRequest *)adunitMARManager andCustomJavaScript:(nonnull NSString *)javaScript;
+- (nonnull instancetype)initWithMultiAdRequestManager:(nonnull ANMultiAdRequest *)marManager andCustomJavaScript:(nullable NSString *)javaScript;
 
 - (void)stopAdLoad;
 - (void)startAutoRefreshTimer;

--- a/sdk/sourcefiles/internal/ANUniversalAdFetcher.m
+++ b/sdk/sourcefiles/internal/ANUniversalAdFetcher.m
@@ -48,6 +48,7 @@
 @property (nonatomic, readwrite, strong)  ANMediationAdViewController       *mediationController;
 @property (nonatomic, readwrite, strong)  ANNativeMediatedAdController      *nativeMediationController;
 @property (nonatomic, readwrite, strong)  ANSSMMediationAdViewController    *ssmMediationController;
+@property (nonatomic, readwrite, strong, nullable)  NSString                *customJavaScript;
 
 @property (nonatomic, readwrite, strong) NSTimer *autoRefreshTimer;
 
@@ -62,18 +63,19 @@
 
 #pragma mark Lifecycle.
 
-- (nonnull instancetype)initWithDelegate:(nonnull id)delegate
+- (nonnull instancetype)initWithDelegate:(nonnull id)delegate andCustomJavaScript:(NSString *)javaScript
 {
     self = [self init];
     if (!self)  { return nil; }
 
     //
     self.delegate = delegate;
+    self.customJavaScript = javaScript;
 
     return  self;
 }
 
-- (nonnull instancetype)initWithDelegate:(nonnull id)delegate andAdUnitMultiAdRequestManager:(nonnull ANMultiAdRequest *)adunitMARManager
+- (nonnull instancetype)initWithDelegate:(nonnull id)delegate andAdUnitMultiAdRequestManager:(nonnull ANMultiAdRequest *)adunitMARManager andCustomJavaScript:(nonnull NSString *)javaScript
 {
     self = [self init];
     if (!self)  { return nil; }
@@ -81,16 +83,18 @@
     //
     self.delegate = delegate;
     self.adunitMARManager = adunitMARManager;
+    self.customJavaScript = javaScript;
 
     return  self;
 }
-- (nonnull instancetype)initWithMultiAdRequestManager: (nonnull ANMultiAdRequest *)marManager
+- (nonnull instancetype)initWithMultiAdRequestManager: (nonnull ANMultiAdRequest *)marManager andCustomJavaScript:(nullable NSString *)javaScript
 {
     self = [self init];
     if (!self)  { return nil; }
 
     //
     self.fetcherMARManager = marManager;
+    self.customJavaScript = javaScript;
 
     return  self;
 }
@@ -372,7 +376,8 @@ ANLogMark();
         CGSize  sizeOfWebView  = [self getWebViewSizeForCreativeWidth:videoAd.width andHeight:videoAd.height];
 
         self.adView = [[ANMRAIDContainerView alloc] initWithSize: sizeOfWebView
-                                                        videoXML: videoAd.content ];
+                                                        videoXML: videoAd.content
+                                                customJavaScript: self.customJavaScript];
 
         self.adView.loadingDelegate = self;
         // Allow ANJAM events to always be passed to the ANAdView
@@ -410,7 +415,8 @@ ANLogMark();
     
     self.adView = [[ANMRAIDContainerView alloc] initWithSize:sizeofWebView
                                                         HTML:standardAd.content
-                                              webViewBaseURL:[NSURL URLWithString:[[[ANSDKSettings sharedInstance] baseUrlConfig] webViewBaseUrl]]];
+                                              webViewBaseURL:[NSURL URLWithString:[[[ANSDKSettings sharedInstance] baseUrlConfig] webViewBaseUrl]]
+                                            customJavaScript:self.customJavaScript];
     self.adView.loadingDelegate = self;
     // Allow ANJAM events to always be passed to the ANAdView
     self.adView.webViewController.adViewANJAMDelegate = self.delegate;

--- a/sdk/sourcefiles/internal/MRAID/ANMRAIDContainerView.h
+++ b/sdk/sourcefiles/internal/MRAID/ANMRAIDContainerView.h
@@ -27,10 +27,12 @@
 
 - (instancetype)initWithSize:(CGSize)size
                         HTML:(NSString *)html
-              webViewBaseURL:(NSURL *)baseURL;
+              webViewBaseURL:(NSURL *)baseURL
+            customJavaScript:(NSString *)javaScript;
 
 - (instancetype) initWithSize: (CGSize)size
-                     videoXML: (NSString *)videoXML;
+                     videoXML: (NSString *)videoXML
+             customJavaScript: (NSString *)javaScript;
 
 
 @property (nonatomic, readonly, assign)                         CGSize  size;

--- a/sdk/sourcefiles/internal/MRAID/ANMRAIDContainerView.m
+++ b/sdk/sourcefiles/internal/MRAID/ANMRAIDContainerView.m
@@ -59,6 +59,7 @@ typedef NS_OPTIONS(NSUInteger, ANMRAIDContainerViewAdInteraction)
 
 @property (nonatomic, readwrite, assign) CGSize size;
 @property (nonatomic, readwrite, strong) NSURL *baseURL;
+@property (nonatomic, readwrite, strong) NSString *customJavaScript;
 
 @property (nonatomic, readwrite, strong) ANAdWebViewController          *webViewController;
 @property (nonatomic, readwrite, strong) ANBrowserViewController        *browserViewController;
@@ -135,15 +136,18 @@ typedef NS_OPTIONS(NSUInteger, ANMRAIDContainerViewAdInteraction)
 - (instancetype)initWithSize:(CGSize)size
                         HTML:(NSString *)html
               webViewBaseURL:(NSURL *)baseURL
+            customJavaScript:(NSString *)javaScript
 {
     self = [self initWithSize:size];
 
     if (self) {
         _baseURL = baseURL;
-
+        _customJavaScript = javaScript;
+        
         self.webViewController = [[ANAdWebViewController alloc] initWithSize: _lastKnownCurrentPosition.size
                                                                         HTML: html
-                                                              webViewBaseURL: baseURL];
+                                                              webViewBaseURL: baseURL
+                                                            customJavaScript:javaScript];
 
         self.webViewController.anjamDelegate    = self;
         self.webViewController.browserDelegate  = self;
@@ -156,13 +160,15 @@ typedef NS_OPTIONS(NSUInteger, ANMRAIDContainerViewAdInteraction)
 
 - (instancetype)initWithSize: (CGSize)size
                     videoXML: (NSString *)videoXML
+            customJavaScript:(NSString *)javaScript
 {
     self = [self initWithSize:size];
 
     if (!self)  { return nil; }
-
+    
     self.webViewController = [[ANAdWebViewController alloc] initWithSize: _lastKnownCurrentPosition.size
-                                                                videoXML: videoXML ];
+                                                                videoXML: videoXML
+                                                        customJavaScript:javaScript];
 
     self.webViewController.anjamDelegate    = self;
     self.webViewController.browserDelegate  = self;
@@ -629,7 +635,8 @@ typedef NS_OPTIONS(NSUInteger, ANMRAIDContainerViewAdInteraction)
         self.expandWebViewController = [[ANAdWebViewController alloc] initWithSize: [ANMRAIDUtil screenSize]
                                                                                URL: expandProperties.URL
                                                                     webViewBaseURL: self.baseURL
-                                                                     configuration: customConfig];
+                                                                     configuration: customConfig
+                                                                  customJavaScript:self.customJavaScript];
         self.expandWebViewController.mraidDelegate = self;
         self.expandWebViewController.browserDelegate = self;
         self.expandWebViewController.anjamDelegate = self;

--- a/sdk/sourcefiles/video/ANInstreamVideoAd.m
+++ b/sdk/sourcefiles/video/ANInstreamVideoAd.m
@@ -83,7 +83,7 @@ NSString * const  exceptionCategoryAPIUsageErr  = @"API usage err.";
     self.clickThroughAction = ANClickThroughActionOpenSDKBrowser;
     self.landingPageLoadsInBackground = YES;
     
-    self.universalAdFetcher = [[ANUniversalAdFetcher alloc] initWithDelegate:self];
+    self.universalAdFetcher = [[ANUniversalAdFetcher alloc] initWithDelegate:self andCustomJavaScript:nil];
     
     [self setupSizeParametersAs1x1];
     [[ANOMIDImplementation sharedInstance] activateOMIDandCreatePartner];


### PR DESCRIPTION
We're offering an ad format to our clients in which we need to display contextual data inside the creative. Ideally we'd simply like to use the customKeywords that are already being passed into the SDK as these include most of the contextual data we need inside the creative.
Unfortunately the only way to use customKeywords inside the creatives is by using Xandr's ad server macros such as "pt0".
There are multiple issues with using the pt macro parameters:
- pt0 - ptx naming isn't very telling of what the macro is for
- there is a limitation of maximum 10(?) pt parameters and we're using pt0 - pt8 currently
- we need an app or API release any time we want to make a new keyword available to a creative

I could have also just injected the customKeywords without the new API, however this way we're more flexible with doing other things too