### PR TITLE
Changed sizesThatShouldConstrainToSuperview to a block

### DIFF
--- a/sdk/sourcefiles/ANSDKSettings.h
+++ b/sdk/sourcefiles/ANSDKSettings.h
@@ -33,7 +33,7 @@
 /**
  Special ad sizes for which the content view should be constrained to the container view.
  */
-@property (nonatomic, copy, nullable) NSArray<NSValue *> *sizesThatShouldConstrainToSuperview;
+@property (nonatomic, copy, nullable) BOOL (^shouldConstrainToSuperview)(NSValue* _Nonnull);
 
 /**
  * Set false to block Location popup asked by Creative, Also notify creative that User denied the request for location.

--- a/sdk/sourcefiles/Categories/ANBannerAdView+ANContentViewTransitions.m
+++ b/sdk/sourcefiles/Categories/ANBannerAdView+ANContentViewTransitions.m
@@ -142,7 +142,10 @@ static NSString *const kANContentViewTransitionsNewContentViewTransitionKey = @"
 - (void)constrainContentView {
     self.contentView.translatesAutoresizingMaskIntoConstraints = NO;
     
-    BOOL shouldConstrainToSuperview = ANSDKSettings.sharedInstance.shouldConstrainToSuperview([NSValue valueWithCGSize:self.contentView.bounds.size]);
+    BOOL shouldConstrainToSuperview = NO;
+    if (ANSDKSettings.sharedInstance.shouldConstrainToSuperview != nil) {
+        shouldConstrainToSuperview = ANSDKSettings.sharedInstance.shouldConstrainToSuperview([NSValue valueWithCGSize:self.contentView.bounds.size]);
+    }
 
     if(CGSizeEqualToSize([self adSize], CGSizeMake(1, 1)) || shouldConstrainToSuperview){
         

--- a/sdk/sourcefiles/Categories/ANBannerAdView+ANContentViewTransitions.m
+++ b/sdk/sourcefiles/Categories/ANBannerAdView+ANContentViewTransitions.m
@@ -142,8 +142,8 @@ static NSString *const kANContentViewTransitionsNewContentViewTransitionKey = @"
 - (void)constrainContentView {
     self.contentView.translatesAutoresizingMaskIntoConstraints = NO;
     
-    BOOL shouldConstrainToSuperview = [ANSDKSettings.sharedInstance.sizesThatShouldConstrainToSuperview containsObject: [NSValue valueWithCGSize:self.contentView.bounds.size]];
-    
+    BOOL shouldConstrainToSuperview = ANSDKSettings.sharedInstance.shouldConstrainToSuperview([NSValue valueWithCGSize:self.contentView.bounds.size]);
+
     if(CGSizeEqualToSize([self adSize], CGSizeMake(1, 1)) || shouldConstrainToSuperview){
         
         [self.contentView an_constrainToSizeOfSuperview];

--- a/tests/UnitTestApp/FunctionalTests/ANBannerAdTestCase.m
+++ b/tests/UnitTestApp/FunctionalTests/ANBannerAdTestCase.m
@@ -159,10 +159,16 @@
     CGRect rect = CGRectMake(0, 0, self.bannerSuperView.frame.size.width, self.bannerSuperView.frame.size.height);
     int adWidth  = 0;
     int adHeight = 10;
-    NSArray *sizes = [NSArray arrayWithObjects:
-                      [NSValue valueWithCGSize:CGSizeMake(adWidth, adHeight)],
-                      nil];
-    ANSDKSettings.sharedInstance.sizesThatShouldConstrainToSuperview  = sizes;
+
+    ANSDKSettings.sharedInstance.shouldConstrainToSuperview = ^BOOL(NSValue *value) {
+        CGSize size = [value CGSizeValue];
+        if (size.width == adWidth && size.height == adHeight) {
+            return true;
+        } else {
+            return false;
+        }
+    };
+    
     CGSize size = CGSizeMake(adWidth, adHeight);
     [self setupBannerWithPlacement:@"13653381" withFrame:rect andSize:size];
 
@@ -184,10 +190,16 @@
     CGRect rect = CGRectMake(0, 0, self.bannerSuperView.frame.size.width, self.bannerSuperView.frame.size.height);
     int adWidth  = 10;
     int adHeight = -42;
-    NSArray *sizes = [NSArray arrayWithObjects:
-                      [NSValue valueWithCGSize:CGSizeMake(adWidth, adHeight)],
-                      nil];
-    ANSDKSettings.sharedInstance.sizesThatShouldConstrainToSuperview  = sizes;
+
+    ANSDKSettings.sharedInstance.shouldConstrainToSuperview = ^BOOL(NSValue *value) {
+        CGSize size = [value CGSizeValue];
+        if (size.width == adWidth && size.height == adHeight) {
+            return true;
+        } else {
+            return false;
+        }
+    };
+
     CGSize size = CGSizeMake(adWidth, adHeight);
     [self setupBannerWithPlacement:@"13653381" withFrame:rect andSize:size];
 
@@ -209,10 +221,16 @@
     CGRect rect = CGRectMake(0, 0, self.bannerSuperView.frame.size.width, self.bannerSuperView.frame.size.height);
     int adWidth  = 10;
     int adHeight = 10;
-    NSArray *sizes = [NSArray arrayWithObjects:
-                      [NSValue valueWithCGSize:CGSizeMake(adWidth, adHeight)],
-                      nil];
-    ANSDKSettings.sharedInstance.sizesThatShouldConstrainToSuperview  = sizes;
+
+    ANSDKSettings.sharedInstance.shouldConstrainToSuperview = ^BOOL(NSValue *value) {
+        CGSize size = [value CGSizeValue];
+        if (size.width == adWidth && size.height == adHeight) {
+            return true;
+        } else {
+            return false;
+        }
+    };
+
     CGSize size = CGSizeMake(adWidth, adHeight);
     [self setupBannerWithPlacement:@"13653381" withFrame:rect andSize:size];
     


### PR DESCRIPTION
The block allows the UI to specify a BOOL instead of sizes when the size should be constrained to the superview.

This have become necessary as we have ad-sizes with wildcard dimensions that need to be constrained to the superview.

See #28 for the original reasoning. 