### PR TITLE
Add disableIDFAUsage to ANSDKSettings

### DIFF
--- a/sdk/sourcefiles/ANSDKSettings.h
+++ b/sdk/sourcefiles/ANSDKSettings.h
@@ -90,4 +90,5 @@ An AppNexus geoOverrideZipCode  is a string value which allows publishers to ove
 */
 @property (nonatomic, readwrite, strong, nullable) NSString *geoOverrideZipCode;
 
+@property (nonatomic, readwrite) BOOL disableIDFAUsage;
 @end

--- a/sdk/sourcefiles/internal/ANGlobal.m
+++ b/sdk/sourcefiles/internal/ANGlobal.m
@@ -78,6 +78,8 @@ NSString * __nonnull ANUUID()
 }
 
 NSString *__nonnull ANAdvertisingIdentifier() {
+    if (ANSDKSettings.sharedInstance.disableIDFAUsage) { return @""; }
+    
     NSString *advertisingIdentifier = [[ASIdentifierManager sharedManager].advertisingIdentifier UUIDString];
     if (advertisingIdentifier) {
         ANLogInfo(@"IDFA = %@", advertisingIdentifier);

--- a/sdk/sourcefiles/internal/config/ANSDKSettings.m
+++ b/sdk/sourcefiles/internal/config/ANSDKSettings.m
@@ -100,6 +100,7 @@
         sdkSettings.locationEnabledForCreative =  YES;
         sdkSettings.enableOpenMeasurement = YES;
         sdkSettings.enableTestMode = NO;
+        sdkSettings.disableIDFAUsage = NO;
         sdkSettings.auctionTimeout = 0;
         sdkSettings.nativeAdAboutToExpireInterval = kAppNexusNativeAdAboutToExpireInterval;
     });


### PR DESCRIPTION
Hi! 
we would like to able to control 3rd party SDKs IDFA usage, `disableIDFAUsage` property will allow us to do so.