### PR TITLE
Use retain instead of assign

### DIFF
--- a/sdk/sourcefiles/native/internal/UIView+ANNativeAdCategory.m
+++ b/sdk/sourcefiles/native/internal/UIView+ANNativeAdCategory.m
@@ -21,7 +21,7 @@
 @dynamic anNativeAdResponse;
 
 - (void)setAnNativeAdResponse:(ANNativeAdResponse *)anNativeAdResponse {
-    objc_setAssociatedObject(self, @selector(anNativeAdResponse), anNativeAdResponse, OBJC_ASSOCIATION_ASSIGN);
+    objc_setAssociatedObject(self, @selector(anNativeAdResponse), anNativeAdResponse, OBJC_ASSOCIATION_RETAIN);
 }
 
 - (ANNativeAdResponse *)anNativeAdResponse {


### PR DESCRIPTION
This will make sure that the pointer doesn't become invalid.

In our project we have a lot of crashes on `ANNativeAdResponse.m` (l. 126). It's not 100% reproducible, but it happens too often. 

We have a `UICollectionView` with a `UICollectionViewDiffableDataSource`, we show a `LoadingCell` and request a Native Ad, when the Native Ad response is returned, we replace the `LoadingCell` with the ad in an `AdCell`. This always works.
At some point we replace the `AdCell` with a `LoadingCell` again, and request a new Native Ad, which also always works.
But once that new Native Ad sends its response, the app sometimes crashes on the line mentioned above. Exception breakpoints gave us the chance to show us that the view is still valid (quicklook even renders it), but the `anNativeAdResponse` will return an object with the same memory pointer as the previous AdResponse, but is now a completely different type of object. So it crashes!

Our best guess on how this happens is the following:
When applying a new `NSDiffableDataSourceSnapshot` on the dataSource, with the animation flag set to true, the cells are recycled and reregistered in quick succession. So our cells are cleaned and reconfigured with the Native Ad response in quick succession too. Our best guess is that iOS is trying to make the animation as smooth as possible, maybe doing some multithread magic in combination with some garbage collection, ending up in this state.

Using assign makes sure that the association is weak, but in this case it's not very safe. Making the association an atomic retain, makes it thread safe and does not introduce any memory issues. It will bind the response to the view displaying the ad, but it will still be released when you register the view to another nativeAdResponse. It will also be released and when you remove the view and if a dev doesn't clean up the view when the ad is no longer needed, there's bigger memory issues to worry about ;)