### PR TITLE
Always check navigationType when opening URL from navigation

### DIFF
--- a/sdk/sourcefiles/internal/ANAdWebViewController.m
+++ b/sdk/sourcefiles/internal/ANAdWebViewController.m
@@ -357,23 +357,13 @@ NSString * __nonnull const  kANLandscape     = @"landscape";
     
     if (self.completedFirstLoad) {
         if (ANHasHttpPrefix(URLScheme)) {
-            if (self.isMRAID) {
-                if (([[mainDocumentURL absoluteString] isEqualToString:[URL absoluteString]]
-                     || navigationAction.targetFrame == nil)
-                    && self.configuration.navigationTriggersDefaultBrowser) {
-                    [self.browserDelegate openDefaultBrowserWithURL:URL];
-                    decisionHandler(WKNavigationActionPolicyCancel);
-                    return;
-                }
-            } else {
-                if (([[mainDocumentURL absoluteString] isEqualToString:[URL absoluteString]]
-                     || navigationAction.navigationType == WKNavigationTypeLinkActivated
-                     || navigationAction.targetFrame == nil)
-                    && self.configuration.navigationTriggersDefaultBrowser) {
-                    [self.browserDelegate openDefaultBrowserWithURL:URL];
-                    decisionHandler(WKNavigationActionPolicyCancel);
-                    return;
-                }
+            if (([[mainDocumentURL absoluteString] isEqualToString:[URL absoluteString]]
+                 || navigationAction.navigationType == WKNavigationTypeLinkActivated
+                 || navigationAction.targetFrame == nil)
+                && self.configuration.navigationTriggersDefaultBrowser) {
+                [self.browserDelegate openDefaultBrowserWithURL:URL];
+                decisionHandler(WKNavigationActionPolicyCancel);
+                return;
             }
         } else if ([URLScheme isEqualToString:@"mraid"]) {
             [self handleMRAIDURL:URL];


### PR DESCRIPTION
We are struggling with mraid ads opening `mediation.adnxs.com` in the system browser spontaneously. 
We do not have repro steps but our best guess is that either native code from AppNexus SDK or javascript cause reload of the web view.
The reload causes navigation to the base url `mediation.adnxs.com` and the code just opens URL in external browser. Our solution is to always check if `navigationType == WKNavigationTypeLinkActivated`