### PR TITLE
Configuration option for SDK browser dismiss button

### DIFF
--- a/sdk/sourcefiles/internal/ANBrowserViewController.m
+++ b/sdk/sourcefiles/internal/ANBrowserViewController.m
@@ -239,8 +239,13 @@ WKNavigationDelegate, WKUIDelegate>
         self.refreshButton.tintColor = nil;
         self.okButton.tintColor = nil;
     }
-    // Setting OK button Localized String
-    self.okButton.title = NSLocalizedString(@"OK", @"LabelForInAppBrowserReturnButton");
+
+    if (ANSDKSettings.sharedInstance.sdkBrowserDismissTitle) {
+        self.okButton.title = ANSDKSettings.sharedInstance.sdkBrowserDismissTitle;
+    } else {
+        // Setting OK button Localized String
+        self.okButton.title = NSLocalizedString(@"OK", @"LabelForInAppBrowserReturnButton");
+    }
 }
 
 - (void)refreshButtons {

--- a/sdk/sourcefiles/public-headers/ANSDKSettings.h
+++ b/sdk/sourcefiles/public-headers/ANSDKSettings.h
@@ -122,4 +122,10 @@ An AppNexus disableIDFVUsage  is a boolean value which exclude the IDFV field in
 @property (nonatomic, readwrite, strong, nullable) NSArray<ANUserId *>  *userIdArray ;
 
 
+/**
+ Specifies a string that is used as the in-app browser dismiss button title.
+*/
+@property (nonatomic, readwrite, strong, nullable) NSString *sdkBrowserDismissTitle;
+
+
 @end


### PR DESCRIPTION
We want to configure the button title `OK` to something else. Currently there is no other way than to override localization file. We don't want to do that because it might clash with some other existing localization.

Here is a way to do it with `ANSDKSettings`, any string (localized or un-localized) can be provided for the button title.